### PR TITLE
Remove URI parsing and synthesis to avoid problem with relative URIs.

### DIFF
--- a/lib/capybara/email/driver.rb
+++ b/lib/capybara/email/driver.rb
@@ -6,11 +6,7 @@ class Capybara::Email::Driver < Capybara::Driver::Base
   end
 
   def follow(url)
-    url = URI.parse(url)
-    host = "#{url.scheme}://#{url.host}"
-    host << ":#{url.port}" unless url.port == url.default_port
-    host_with_path = File.join(host, url.path)
-    Capybara.current_session.visit([host_with_path, url.query].compact.join('?'))
+    Capybara.current_session.visit(url)
   end
 
   def body


### PR DESCRIPTION
I ran into problems with calling current_email.click_link on a relative href. Not sure what the value is of parsing and reassembling the url in the follow method? Passing the url straight through to Capybara works just fine.