### PR TITLE
Capybara.save_path instead of deprecated Capybara.save_and_open_page_path

### DIFF
--- a/lib/capybara/node/email.rb
+++ b/lib/capybara/node/email.rb
@@ -40,7 +40,7 @@ class Capybara::Node::Email < Capybara::Node::Document
   #
   def save_page(path = nil)
     path ||= "capybara-email-#{Time.new.strftime("%Y%m%d%H%M%S")}#{rand(10**10)}.html"
-    path = File.expand_path(path, Capybara.save_and_open_page_path) if Capybara.save_and_open_page_path
+    path = File.expand_path(path, Capybara.save_path) if Capybara.save_path
 
     FileUtils.mkdir_p(File.dirname(path))
 


### PR DESCRIPTION
Capybara has deprecated this method [here](https://github.com/jnicklas/capybara/blob/0b575829bc2d1c067c0114fd7c1984d28cff9b70/lib/capybara.rb#L383-L387)